### PR TITLE
LIBASPACE-320. Provide repo_id param explicity as a symbol.

### DIFF
--- a/backend/controllers/department_list.rb
+++ b/backend/controllers/department_list.rb
@@ -18,7 +18,7 @@ class ArchivesSpaceService < Sinatra::Base
 		.permissions([])
   	.returns([200, "[(:department_list)]"]) \
   do 
-    handle_unlimited_listing(DepartmentList, params)
+    handle_unlimited_listing(DepartmentList, {:repo_id => params[:repo_id]})
   end
 
 


### PR DESCRIPTION
There is a change in the archivesspace codebase on how the params are processed, and it is no longer converting string to symbols.

See https://github.com/archivesspace/archivesspace/commit/13786edb617ea755f42a3fba259a2dc15550e129#diff-346417db100d7c0e3e61b0c4ed5e79d6bf8e0f44be26d508d5bbbb45aa054d1dR528-R559

https://issues.umd.edu/browse/LIBASPACE-320