### PR TITLE
LIBASPACE-404. Update plugin for ArchivesSpace 4.1.1

### DIFF
--- a/backend/model/sequence.rb
+++ b/backend/model/sequence.rb
@@ -1,0 +1,92 @@
+# UMD Customization
+# This stock ArchivesSpace file was removed in ArchivesSpace 4.0.0
+# (see https://github.com/archivesspace/archivesspace/commit/4fabc1b201647eb80eba5cabd8efcf495e28e90d)
+#
+# However, this plugin still relies on it, so copied the file in from
+# ArchivesSpace 3.5.1.
+# End UMD Customization
+class Sequence
+  # DEPRECATED: this is dead code since ArchivesSpace v2
+
+  QUEUE = java.util.concurrent.ArrayBlockingQueue.new(1024)
+
+  def self.init(sequence, value)
+    result = java.util.concurrent.CompletableFuture.new
+    QUEUE.add({action: :init, sequence: sequence, value: value, result: result})
+    result.get
+    nil
+  end
+
+  def self.get(sequence)
+    result = java.util.concurrent.CompletableFuture.new
+    QUEUE.add({action: :get, sequence: sequence, result: result})
+    result.get
+  end
+
+  def self._handle_get(request, initialised_sequences)
+    sequence = request[:sequence]
+    DB.open(true) do |db|
+      if !initialised_sequences[sequence]
+        initialised_sequences[sequence] = true
+
+        DB.attempt {
+          db[:sequence].insert(:sequence_name => sequence.to_s, :value => 0)
+          request[:result].complete(0)
+          return
+        }.and_if_constraint_fails {
+          # Sequence is already defined, which is fine
+        }
+      end
+
+      # If we make it to here, the sequence already exists and needs to be incremented
+      1000.times do
+        old_value = db[:sequence].filter(:sequence_name => sequence.to_s).get(:value)
+        updated_count = db[:sequence].filter(:sequence_name => sequence.to_s, :value => old_value).
+                          update(:value => old_value + 1)
+
+        if updated_count == 0
+          # Need to retry
+          sleep(0.01)
+        elsif updated_count == 1
+          request[:result].complete(old_value + 1)
+          return
+        else
+          Log.error("Unrecognised response from SQL update when generating next element in sequence '#{sequence}': #{updated_count}")
+        end
+      end
+
+      Log.error("Gave up trying to generate a sequence number for: '#{sequence}'")
+      request[:result].completeExceptionally(java.lang.RuntimeException.new("Gave up trying to generate a sequence number for: '#{sequence}'"))
+    end
+  end
+
+  Thread.new do
+    initialised_sequences = {}
+
+    while request = QUEUE.take
+      begin
+        if request[:action] == :init
+          DB.open(true) do |db|
+            DB.attempt {
+              db[:sequence].insert(:sequence_name => request[:sequence].to_s, :value => request[:value])
+            }.and_if_constraint_fails {
+              # Sequence is already defined, which is fine
+            }
+
+            request[:result].complete(nil)
+          end
+        elsif request[:action] == :get
+          _handle_get(request, initialised_sequences)
+        else
+          request[:result].completeExceptionally(java.lang.RuntimeException.new("Unrecognised action"))
+        end
+      rescue
+        Log.error("Error while generating sequence: $!")
+        Log.exception($!)
+        request[:result].completeExceptionally(java.lang.RuntimeException.new("Unexpected error"))
+      end
+    end
+
+  end
+
+end

--- a/docs/Customizations.md
+++ b/docs/Customizations.md
@@ -18,6 +18,11 @@ The following stock files were deleted:
 
 The following files have been added:
 
+* backend/model/sequence.rb
+
+  This stock ArchivesSpace file was removed in ArchivesSpace 4.0.0, but is still
+  used by this plugin. Added file from ArchivesSpace 3.5.1.
+
 * backend/model/mixins/four_id_generator.rb
 * backend/model/resource.rb
 * frontend/assets/resource_identifiers.js

--- a/docs/Customizations.md
+++ b/docs/Customizations.md
@@ -114,6 +114,8 @@ or more department codes, so they should not be run in production.
 4) On the "New Accession" form, verify that, in the four-part "Identifier"
    field:
 
+   * the first component represents the current fiscal year (same as the actual
+     year through June, the next year on July 1st or later), and is not editable
    * the second component has an "XXXX" placeholder, and is not editable
    * The third component is a drop-down list consisting of the department codes
    * The fourth component is empty, but is editable
@@ -135,9 +137,9 @@ or more department codes, so they should not be run in production.
    displayed.
 
 7) On the "Test Accession" detail page, verify that in the four-part
-   "Identifier" field, the second component is a numeric value such as `0001`
-   and the third component matches the department code selected in the previous
-   steps.
+   "Identifier" field, the first component is the fiscal year, the second
+   component is a numeric value such as `0001` and the third component matches
+   the department code selected in the previous steps.
 
 8) From the navigation bar, left-click "Create | Resource". The "New Resource"
    form will be shown.

--- a/frontend/assets/repository_menu.js
+++ b/frontend/assets/repository_menu.js
@@ -5,5 +5,5 @@ $(function() {
     $target = $('li.repo-container .dropdown-submenu > a:contains("Plug-ins")').parent().find('.dropdown-menu');
   }
 
-  $target.append('<li><a href="/plugins/yale_accessions/department_codes">Department Codes</a></li>');
+  $target.append('<li class="dropdown-item"><a href="/plugins/yale_accessions/department_codes">Department Codes</a></li>');
 })

--- a/frontend/views/department_list/edit.html.erb
+++ b/frontend/views/department_list/edit.html.erb
@@ -1,22 +1,26 @@
 <%= setup_context(:title => I18n.t("plugins.yale_accessions.manage_department_list"), :controller => :yale_accessions) %>
 
-<h2><%= I18n.t("plugins.yale_accessions.manage_department_list") %></h2>
-<p><%= I18n.t("plugins.yale_accessions.manage_department_list_instructions") %></p>
+<div class="d-flex">
+  <div class="col-12">
+    <h2><%= I18n.t("plugins.yale_accessions.manage_department_list") %></h2>
+    <p><%= I18n.t("plugins.yale_accessions.manage_department_list_instructions") %></p>
 
-<%= form_for @department_list, as: 'department_list', url: '/plugins/yale_accessions/department_codes', :html => { :id => "department_list_#{@department_list['uri'].sub(/.*\//, '')}", :class => "department_list_update" } do |f| %> 
+    <%= form_for @department_list, as: 'department_list', url: '/plugins/yale_accessions/department_codes', :html => { :id => "department_list_#{@department_list['uri'].sub(/.*\//, '')}", :class => "department_list_update" } do |f| %>
 
-  <% @department_list['codes'].each do |code| %>
+      <% @department_list['codes'].each do |code| %>
 
-    <script>
-     DEPARTMENT_CODES.push("<%= code %>");
-    </script>
+        <script>
+        DEPARTMENT_CODES.push("<%= code %>");
+        </script>
 
-  <% end %>
-  <input class="tm-input tm-input-info" type="text" data-original-title="" style="width:9em;" placeholder="Enter codes" name="tags" autocomplete="off">
+      <% end %>
+      <input class="tm-input tm-input-info" type="text" data-original-title="" style="width:9em;" placeholder="Enter codes" name="tags" autocomplete="off">
 
-  <input type="hidden" name="department_list_uri" value="<%= @department_list['uri'] %>">
+      <input type="hidden" name="department_list_uri" value="<%= @department_list['uri'] %>">
 
-  <div class="form-actions">
-    <button id="department_codes_save" type="submit" class="btn btn-primary disabled">Save</button>
+      <div class="form-actions">
+        <button id="department_codes_save" type="submit" class="btn btn-primary disabled">Save</button>
+      </div>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
Updated the plugin as follows to be compatible with ArchivesSpace 4.1.1:

* Added “backend/model/sequence.rb” from ArchivesSpace 3.5.1.

  This stock ArchivesSpace file was removedin 4.0.0, but is still needed by this plugin, so added the ArchivesSpace 3.5.1 version of the file to the plugin code.

* CSS Styling
  * frontend/assets/repository_menu.js - Added the "dropdown-item" CSS style to "Department Codes" menu link, so that it would match the other items in the drop-down menu.
  * frontend/views/department_list/edit.html.erb - Placed HTML within “d-flex”/”col-12” divs, to be more consistent with the layout of other pages.

https://umd-dit.atlassian.net/browse/LIBASPACE-404